### PR TITLE
fix: lock sourceStatus mutex in GetCommittedLSN

### DIFF
--- a/streamer/worker.go
+++ b/streamer/worker.go
@@ -140,6 +140,7 @@ func GetCommittedLSN(database, sid string, sourceCommittedLSN pglogrepl.LSN) pgl
 
 	// step 1 find lowest dirty LSN
 	for i := range Workers {
+		Workers[i].s.Lock()
 		if status, ok := Workers[i].s.m[dbsid]; ok {
 			if status.WrittenLSN > status.CommittedLSN { // worker has written requests but not committed
 				if status.WrittenLSN < lowestDirtyLSN || lowestDirtyLSN == 0 {
@@ -147,10 +148,12 @@ func GetCommittedLSN(database, sid string, sourceCommittedLSN pglogrepl.LSN) pgl
 				}
 			}
 		}
+		Workers[i].s.Unlock()
 	}
 	// log.Debug("Found Lowest dirty LSN", "lowestDirtyLSN", lowestDirtyLSN)
 	// step 2 find highest committed transaction in destination already committed in the source
 	for i := range Workers {
+		Workers[i].s.Lock()
 		// log.Debug("Worker info", "i", i, "m", Workers[i].s.m[dbsid])
 		if status, ok := Workers[i].s.m[dbsid]; ok {
 			if (status.CommittedLSN < lowestDirtyLSN || lowestDirtyLSN == 0) &&
@@ -159,6 +162,7 @@ func GetCommittedLSN(database, sid string, sourceCommittedLSN pglogrepl.LSN) pgl
 				highestCommittedLSN = status.CommittedLSN
 			}
 		}
+		Workers[i].s.Unlock()
 	}
 	// log.Debug("Found highest committed LSN", "highestCommittedLSN", highestCommittedLSN, "sourceCommittedLSN", sourceCommittedLSN)
 	return highestCommittedLSN


### PR DESCRIPTION
Fixes #13

GetCommittedLSN reads Workers[i].s.m without holding the mutex while other goroutines write to it via Write()/Commit()/SetCommittedLSN. Under high concurrency this triggers Go's concurrent map access detector and crashes the process.

Added Lock/Unlock around each per-worker map read, same pattern the write paths already use. Using explicit Unlock() instead of defer to release the lock between loop iterations.

— saschabuehrle